### PR TITLE
chore: simple-encryptor to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "cookie": "^0.3.1",
     "cookie-signature": "^1.1.0",
-    "simple-encryptor": "^1.4.0"
+    "simple-encryptor": "^3.0.0"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",


### PR DESCRIPTION
Updated the simple-encryptor package, it uses a new version of encryption (`aes-256-cbc` instead of `aes-256`). This will allow you to use this in the prebuilt version of node used within electron.